### PR TITLE
Modifiers collisions with folder names

### DIFF
--- a/src/lib/modifiers.js
+++ b/src/lib/modifiers.js
@@ -176,24 +176,33 @@ function parseModifiers(mods, modArr) {
 
       switch(mod.desc){
       case 'height':
-        mods.height = string.sanitize(value);
-        if (mods.height > dimensionLimit) {
-          mods.height = dimensionLimit;
+        value = string.sanitize(value);
+        if (value) {
+          mods.height = value;
+          if (mods.height > dimensionLimit) {
+            mods.height = dimensionLimit;
+          }
+          mods.hasModStr = true;
         }
-        mods.hasModStr = true;
         break;
       case 'width':
-        mods.width = string.sanitize(value);
-        if (mods.width > dimensionLimit) {
-          mods.width = dimensionLimit;
+        value = string.sanitize(value);
+        if (value) {
+          mods.width = value;
+          if (mods.width > dimensionLimit) {
+            mods.width = dimensionLimit;
+          }
+          mods.hasModStr = true;
         }
-        mods.hasModStr = true;
         break;
       case 'square':
-        mods.action = 'square';
-        mods.height = string.sanitize(value);
-        mods.width = string.sanitize(value);
-        mods.hasModStr = true;
+        value = string.sanitize(value);
+        if (value) {
+          mods.action = 'square';
+          mods.height = value;
+          mods.width = value;
+          mods.hasModStr = true;
+        }
         break;
       case 'gravity':
         value = string.sanitize(value, 'alpha');
@@ -203,12 +212,18 @@ function parseModifiers(mods, modArr) {
         mods.hasModStr = true;
         break;
       case 'top':
-        mods.y = string.sanitize(value);
-        mods.hasModStr = true;
+        value = string.sanitize(value);
+        if (value) {
+          mods.y = value;
+          mods.hasModStr = true;
+        }
         break;
       case 'left':
-        mods.x = string.sanitize(value);
-        mods.hasModStr = true;
+        value = string.sanitize(value);
+        if (value) {
+          mods.x = value;
+          mods.hasModStr = true;
+        }
         break;
       case 'crop':
         value = string.sanitize(value, 'alpha');

--- a/test/src/lib/modifiers-spec.js
+++ b/test/src/lib/modifiers-spec.js
@@ -50,6 +50,39 @@ describe('Modifiers module', function(){
     });
   });
 
+  // Is not a real modifier
+  describe('No modifiers', function(){
+    it('should not set action to square', function(){
+      var request = '/stop/path/to/image.jpg';
+      mod.parse(request).action.should.equal('original');
+    });
+
+    it('should not set action to height', function(){
+      var request = '/hooops/path/to/image.jpg';
+      mod.parse(request).action.should.equal('original');
+    });
+
+    it('should not set action to width', function(){
+      var request = '/wooops/path/to/image.jpg';
+      mod.parse(request).action.should.equal('original');
+    });
+
+    it('should not set action to top', function(){
+      var request = '/yooops/path/to/image.jpg';
+      var p = mod.parse(request);
+      expect(p.y).to.be.empty;
+      p.hasModStr.should.equal(false);
+    });
+
+    it('should not set action to left', function(){
+      var request = '/xooops/path/to/image.jpg';
+      var p = mod.parse(request);
+      expect(p.x).to.be.empty;
+      p.hasModStr.should.equal(false);
+    });
+  });
+
+
 
   // Gravity
   describe('Gravity', function(){


### PR DESCRIPTION
File path such as:

```
/wooops/path/file.jpeg
/hooops/string/path/file.jpeg
etc ...
```
will have the first part of the path considered as a modifier (width and height) even though "ooops" is not a valid number.